### PR TITLE
Fixes for redpanda service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,29 +2,25 @@ version: "3.8"
 services:
   redpanda:
     command:
-    - redpanda
-    - start
-    - --smp
-    - '1'
-    - --reserve-memory
-    - 0M
-    - --overprovisioned
-    - --node-id
-    - '0'
-    - --kafka-addr
-    - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-    - --advertise-kafka-addr
-# Pretty sure we don't want `localhost` here
-    - PLAINTEXT://redpanda:29092,OUTSIDE://redpanda:9092
-    - --set
-# Use auto create topics for convenience
-    - 'auto_create_topics_enabled=true'
-    # NOTE: Please use the latest version here!
-    image: docker.vectorized.io/vectorized/redpanda:latest
+      - redpanda start
+      - --smp 1
+      - --reserve-memory
+      - 0M
+      - --overprovisioned
+      - --node-id 0
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+      - --set
+      - 'auto_create_topics_enabled=true'
+    image: docker.vectorized.io/vectorized/redpanda:v21.9.3
     ports:
-    - 9092:9092
-    - 29092:29092
+      - 9092:9092
+      - 29092:29092
     container_name: redpanda
+    volumes:
+      - ./var/lib/redpanda/data:/var/lib/redpanda/data
 
   tremor_in:
     image: tremorproject/tremor:edge


### PR DESCRIPTION
* replaced `:latest` with `:v21.9.3`
* --smp `1` was causing problems
* 'localhost' for external advertised address
* added data dir (persist data btwn restarts)